### PR TITLE
setup.py: add installation dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,5 @@ setup(
                     'data/js/*.js', 'data/js/*/*.js', 'data/theme/*/*',
                     'data/figures/*']},
     zip_safe=False,
+    install_requires=['jinja2', 'markdown'],
 )


### PR DESCRIPTION
Add dependencies on jinja2 and markdown so that they are installed when `pip
install`-ed into a fresh virtualenv (or `python setup.py`-ed for that
matter).
