### PR TITLE
Fixes mathjax bugs

### DIFF
--- a/slidedeck/mdx_mathjax.py
+++ b/slidedeck/mdx_mathjax.py
@@ -1,0 +1,20 @@
+import markdown
+
+class MathJaxPattern(markdown.inlinepatterns.Pattern):
+
+    def __init__(self):
+        markdown.inlinepatterns.Pattern.__init__(self, r'(?<!\\)(\$\$?)(.+?)\2')
+
+    def handleMatch(self, m):
+        node = markdown.util.etree.Element('mathjax')
+        node.text = markdown.util.AtomicString(m.group(2) + m.group(3) + m.group(2))
+        return node
+
+class MathJaxExtension(markdown.Extension):
+    def extendMarkdown(self, md, md_globals):
+        # Needs to come before escape matching because \ is pretty important in LaTeX
+        md.inlinePatterns.add('mathjax', MathJaxPattern(), '<escape')
+
+def makeExtension(configs=None):
+    return MathJaxExtension(configs)
+

--- a/slidedeck/render.py
+++ b/slidedeck/render.py
@@ -7,6 +7,7 @@ import codecs
 import re
 import jinja2
 import markdown
+from slidedeck.mdx_mathjax import MathJaxExtension
 
 #############################################################################
 # Globals
@@ -56,7 +57,7 @@ def render_slides(md, template_fn):
         remainder_index = metadata and 1 or 0
         # Get the content from the rest of the slide.
         content_section = '\n\n'.join(sections[remainder_index:])
-        html = markdown.markdown(content_section)
+        html = markdown.markdown(content_section, extensions=[MathJaxExtension()])
         slide['content'] = postprocess_html(html, metadata)
 
         slides.append(slide)


### PR DESCRIPTION
There were some bugs due to markdown processing the mathjax for underscores that came up, especially when using literal curly braces `$\{ \}$` and linebreaks `\\`. This fixes them.

Code from https://github.com/mayoff/python-markdown-mathjax
