### PR TITLE
Use setuptools console script for better windows support.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-jinja2
-markdown
-watchdog

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,7 @@ you change the content (useful for iterative development).
 
 DOCLINES = __doc__.split("\n")
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup, find_packages
 
 CLASSIFIERS = """\
 Development Status :: 3 - Alpha
@@ -34,19 +31,19 @@ Topic :: Internet :: WWW/HTTP
 
 setup(
     name='slidedeck',
-    version='0.11',
+    version='0.12',
     author='Robert McGibbon',
     author_email='rmcgibbo@gmail.com',
     url='https://github.com/rmcgibbo/slidedeck',
     description=DOCLINES[0],
     long_description="\n".join(DOCLINES[2:]),
     classifiers = CLASSIFIERS.splitlines(),
-    packages=['slidedeck'],
-    scripts=['scripts/slidedeck'],
+    packages=find_packages(),
+    entry_points={'console_scripts': ['slidedeck=slidedeck.scripts.slidedeck:main']},
     platforms = ["Linux", "Mac OS-X", "Unix"],
     package_data={'slidedeck': ['data/base.html', 'data/slides.md',
                     'data/js/*.js', 'data/js/*/*.js', 'data/theme/*/*',
                     'data/figures/*']},
     zip_safe=False,
-    install_requires=['jinja2', 'markdown'],
+    install_requires=['jinja2', 'markdown', 'watchdog'],
 )

--- a/slidedeck/scripts/slidedeck.py
+++ b/slidedeck/scripts/slidedeck.py
@@ -1,63 +1,68 @@
-#!/usr/bin/env python
-
 #############################################################################
 # Imports
 #############################################################################
 
 import sys
 import argparse
+import pkg_resources
 from slidedeck import render, create
+
+__version__ = pkg_resources.get_distribution("slidedeck").version
 
 #############################################################################
 # Functions
 #############################################################################
 
 def main():
-    parser = argparse.ArgumentParser(description="""
+    p = argparse.ArgumentParser(description="""
     slidedeck is a tool for creating HTML5 slideshows in markdown, based on
     the google io 2012 slidedeck. To get started and create your own slideshow,
     use the `create` command.""")
-    subparsers = parser.add_subparsers(title='command', dest='action')
+    p.add_argument(
+        '-v', '--version',
+        action='version',
+        version = 'slidedeck %s' % __version__)
 
-    parser_create_help='''Render a slideshow
-        by translating the the markdown source into HTML5.'''
-    parser_create = subparsers.add_parser("create", help=parser_create_help,
-        description=parser_create_help)
-    parser_create.add_argument('path', help='''Name of the slideshow
+
+    subs = p.add_subparsers(title='command', dest='action')
+
+    create_help='''Render a slideshow by translating the the markdown source
+        into HTML5.'''
+    create = subs.add_parser("create", help=create_help,
+        description=create_help)
+    create.add_argument('path', help='''Name of the slideshow
         to create. This will create a new directory at this path, and
         populate it with the necessary files for a skeleton slideshow.''')
 
-    parser_render_help = """Render a slideshow by translating the the markdown
+    render_help = """Render a slideshow by translating the the markdown
         source into HTML5."""
-    parser_render = subparsers.add_parser("render", help=parser_render_help,
-        description=parser_render_help)
-    parser_render.add_argument('-i', '--markdown', help='''The markdown source file.
+    render = subs.add_parser("render", help=render_help, description=render_help)
+    render.add_argument('-i', '--markdown', help='''The markdown source file.
         Default="slides.md"''', default='slides.md')
-    parser_render.add_argument('-o', '--output', help='''The outut HTML file.
+    render.add_argument('-o', '--output', help='''The outut HTML file.
         Default="index.html"''', default='index.html')
-    parser_render.add_argument('-t', '--template', help='''The template filename
+    render.add_argument('-t', '--template', help='''The template filename
         Default="base.html"''', default='base.html')
 
 
-    parser_watch_help = """Run a small process that watches the slides' 
+    watch_help = """Run a small process that watches the slides'
         markdown file for changes and rerenders the presentation to HTML
         whenever the slides are modified."""
-    parser_watch = subparsers.add_parser("watch", help=parser_watch_help,
-        description=parser_watch_help)
-    parser_watch.add_argument('-i', '--markdown', help='''The markdown source file.
+    watch = subs.add_parser("watch", help=watch_help, description=watch_help)
+    watch.add_argument('-i', '--markdown', help='''The markdown source file.
         Default="slides.md"''', default='slides.md')
-    parser_watch.add_argument('-o', '--output', help='''The outut HTML file.
+    watch.add_argument('-o', '--output', help='''The outut HTML file.
         Default="index.html"''', default='index.html')
-    parser_watch.add_argument('-t', '--template', help='''The template filename
+    watch.add_argument('-t', '--template', help='''The template filename
         Default="base.html"''', default='base.html')
 
     if len(sys.argv) == 1:
         # if nothing is specfied on the command line, print the help
         # text to try to be useful.
-        parser.parse_args(['-h'])
+        p.parse_args(['-h'])
         sys.exit(1)
 
-    args = parser.parse_args()
+    args = p.parse_args()
 
     if args.action == 'render':
         render.process_slides(args.markdown, args.output, args.template)


### PR DESCRIPTION
This is a fix for #34. It does a couple other things too.
- Remove `requirements.txt` and consolidate with `install_requires`. For PyPI packages, using install_requires makes more sense. https://caremad.io/2013/07/setup-vs-requirement/
- The setuptools `console_script` entry point works correctly on windows, whereas `distutils` scripts does not.
- Add a `-v` version command, because why not.