### PR TITLE
Check and convert EOL encoding of slides.md

### DIFF
--- a/slidedeck/render.py
+++ b/slidedeck/render.py
@@ -76,6 +76,10 @@ def process_slides(markdown_fn, output_fn, template_fn):
         raise OSError('The markdown file "%s" could not be found.' % markdown_fn)
     md = codecs.open(markdown_fn, encoding='utf8').read()
 
+    # Check for Dos\Windows line encoding \r\n and convert to unix style \n
+    if '\r\n' in md:
+        md = md.replace('\r\n', '\n')
+
     slides = render_slides(md, template_fn)
     write_slides(slides, output_fn)
 


### PR DESCRIPTION
## Check and convert EOL encoding

While using slidedeck on Windows x64, editing `slides.md` with notepad++, the slides were not rendered correctly with `slidedeck render`, output was always: 

> Parsed slide deck settings, and found setting for: author, title, contact.
> Compiled 1 slides.

although I had more slides. The resulting `index.html` also was broken (missing and mixing slides and content).

**This pull request** checks for Dos\Windows line encoding `\r\n` and converts it to UNIX style `\n` directly after reading `slides.md`, as the subsequent detection of slides in `slides.md` is based on `\n` newlines.